### PR TITLE
Make DESTROY_CLUSTER a top level parameter so that it can be changed

### DIFF
--- a/common-parameters.yaml
+++ b/common-parameters.yaml
@@ -5,3 +5,4 @@
       - kraken-params
       - terraform-params
       - coreos-params
+      - destroy-params

--- a/destroy-params.yaml
+++ b/destroy-params.yaml
@@ -1,0 +1,8 @@
+---
+- parameter:
+    name: destroy-params
+    parameters:
+      - bool:
+          name: DESTROY_CLUSTER
+          default: true
+          description: "true if the cluster should be destroyed, false if this step should be skipped."

--- a/kraken-destroy/kraken-destroy.yaml
+++ b/kraken-destroy/kraken-destroy.yaml
@@ -9,10 +9,6 @@
     parameters:
       - clustername-params
       - common-params
-      - bool:
-          name: DESTROY_CLUSTER
-          default: true
-          description: "true if the cluster should be destroyed, false if this step should be skipped."
     properties:
       - github:
           url: https://github.com/Samsung-AG/kraken/


### PR DESCRIPTION
when starting jobs. Note that I am curious if anyone is aware of a way to expose downstream job parameters in the top level job. If that that would be cleaner than cluttering the top level job...