### PR TITLE
Add PR job for kraken-ci-jobs

### DIFF
--- a/job-list.yaml.inc
+++ b/job-list.yaml.inc
@@ -11,3 +11,4 @@
 - '{name}-update-github-pages'
 - '{name}-upload-to-s3'
 - '{name}-update-jobs'
+- '{name}-ci-jobs-pr'

--- a/kraken-ci-jobs-pr/include-raw001-kraken-ci-jobs-pr.sh
+++ b/kraken-ci-jobs-pr/include-raw001-kraken-ci-jobs-pr.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cp /etc/jenkins_jobs/kraken-ci.yaml .
+jenkins-jobs test --recursive .

--- a/kraken-ci-jobs-pr/kraken-ci-jobs-pr.yaml
+++ b/kraken-ci-jobs-pr/kraken-ci-jobs-pr.yaml
@@ -1,0 +1,35 @@
+---
+- job-template:
+    name: '{name}-ci-jobs-pr'
+    description: 'Do not edit this job through the web! Runs against pull requests made against kraken-ci-jobs'
+    project-type: freestyle
+    logrotate:
+      numToKeep: 100
+    properties:
+      - github:
+          url: https://github.com/Samsung-AG/kraken-ci-jobs/
+    scm:
+      - git:
+          url: git@github.com:Samsung-AG/kraken-ci-jobs.git
+          credentials-id: jenkins-ssh
+          refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+          branches:
+            - ${{ghprbActualCommit}}
+          browser: auto
+          wipe-workspace: false
+          skip-tag: true
+    wrappers:
+      - workspace-cleanup
+    triggers:
+      - github-pull-request:
+          admin-list: '{obj:ci_admin_list}'
+          github-hooks: true
+    builders:
+      - shell: 
+          !include-raw-escape: include-raw001-kraken-ci-jobs-pr.sh
+    publishers:
+      - slack-publisher:
+          slack_domain: '{slack_domain}'
+          slack_api_token: '{slack_api_token}'
+          ci_hostname: '{ci_hostname}'
+          slack_room: '{slack_room}'


### PR DESCRIPTION
I'd like to refactor the templates/project layout, but it's a pain
to do so on my dev machine and still be able to test.  So let's get a PR
job to do some of this for me.